### PR TITLE
Remove console.log statement from writing when a BufferStream underflows.

### DIFF
--- a/lib/buffer-stream.js
+++ b/lib/buffer-stream.js
@@ -45,7 +45,6 @@ exports.BufferStream = (function() {
 
   BufferStream.prototype.assertBytesAvailable = function(amountNeeded) {
     if (amountNeeded + this._offset > this._buffer.length) {
-      console.log('Need %d, length %d', amountNeeded + this._offset, this._buffer.length);
       throw new BufferStream.StreamIndexOutOfBoundsError('Index out of bounds');
     }
   };

--- a/src/buffer-stream.coffee
+++ b/src/buffer-stream.coffee
@@ -35,7 +35,6 @@ class exports.BufferStream
     
   assertBytesAvailable: (amountNeeded) ->
     if amountNeeded + @_offset > @_buffer.length
-      console.log 'Need %d, length %d', amountNeeded + @_offset, @_buffer.length
       throw new BufferStream.StreamIndexOutOfBoundsError 'Index out of bounds'
       
   currentOffset: -> @_offset - @_offsetStart


### PR DESCRIPTION
Is a simple patch to remove the console.log statement.
