### PR TITLE
Fix StreamIndexOutOfBoundsError w/null value (0xFFFF val.length)

### DIFF
--- a/src/row.token.coffee
+++ b/src/row.token.coffee
@@ -63,6 +63,11 @@ class exports.RowToken extends Token
           else val.length = column.length
       if val.length is 0 and column.type.emptyPossible
         val.buffer = new Buffer 0
+      else if val.length is 0xffff and column.isNullable
+        if column.type.emptyPossible
+          val.length = -1
+        else
+          val.length = 0
       else if val.length > 0
         val.buffer = stream.readBuffer val.length
       @values[index] = val


### PR DESCRIPTION
I assume a nullable column with a value's length of 0xFFFF should actually become null (see #33). The length is set based on emptyPossible so that is does not break the logic in the isNull method and returns a null value (instead of an empty string).

I do not know if a length of 0xFFFF should always be null or perhaps only for uint16LE length type or VarChar sql types. I would appreciate it if anyone could check this.

Sorry I don't have any tests.
